### PR TITLE
Pull from git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
 FROM ubuntu:14.04
 
-# Install the packages we need
+# Install the packages we need for getting things done
 RUN apt-get update && \
     apt-get install -y \
       build-essential \
+      dos2unix \
+      git \
+    && \
+    apt-get clean
+
+# Install the packages we need for Jekyll
+RUN apt-get update && \
+    apt-get install -y \
       node \
       python-pygments \
       ruby \
@@ -18,9 +26,13 @@ RUN gem install \
 # Port where we serve the files
 EXPOSE 4000
 
-# Bring in our files, so we have a stable snapshot
-COPY /site /site
+# Volume where the site will persist
+VOLUME ["/site"]
 
-# Our command
-WORKDIR /site
-CMD ["jekyll", "serve", "--host", "0.0.0.0"]
+# Our wrapper script
+COPY run.sh /tmp/run.sh
+RUN dos2unix /tmp/run.sh
+RUN chmod a+x /tmp/run.sh
+
+# Run the wrapper script
+CMD ["/tmp/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Ensure our repository is defined
+if [[ ! -n $JEKYLL_GIT_REPOSITORY ]] ; then
+  echo "\$JEKYLL_GIT_REPOSITORY not defined"
+  exit 1
+fi
+
+# Check whether this is our first time running, such that we need to clone
+if [[ ! -d /site/.git ]] ; then
+  git clone $JEKYLL_GIT_REPOSITORY /site
+fi
+
+# Change into the site directory
+cd /site
+
+# Ensure we have any site updates
+# http://grimoire.ca/git/stop-using-git-pull-to-deploy
+git fetch --all
+git checkout --force origin/master
+
+# Launch our server, making it the process to ensure Docker behaves
+# http://www.projectatomic.io/docs/docker-image-author-guidance/
+exec jekyll serve --host 0.0.0.0


### PR DESCRIPTION
Instead of pulling from a local directory that needs to separately be cloned from git, pull directly from git.

This mostly required introducing a wrapper script to allow an environment variable specifying the repository.